### PR TITLE
'bin/' halfway path gets '/' removed

### DIFF
--- a/ports/k210-freertos/platform/sdk/Makefile
+++ b/ports/k210-freertos/platform/sdk/Makefile
@@ -31,7 +31,7 @@ build_env:
 compile: build_env
 	-mkdir -p build
 	MAKE_J_NUMBER=`cat /proc/cpuinfo | grep vendor_id | wc -l`
-	cd build && cmake ../$(SDK_DIR_NAME)/ -DPROJ=hello_world -DTOOLCHAIN=$(subst bin/,bin,$(dir $(CROSS_COMPILE))) && make -j${MAKE_J_NUMBER}
+	cd build && cmake ../$(SDK_DIR_NAME)/ -DPROJ=hello_world -DTOOLCHAIN=$(patsubst %/,%,$(dir $(CROSS_COMPILE))) && make -j${MAKE_J_NUMBER}
 	cp ${CUR_DIR}/${OUTPUT_DIR}/lib/libkendryte.a ${BIN_DIR}/
 
 include_mk: build_env


### PR DESCRIPTION
I have my tool chain in a path that contains 'bin/'. The subst statement in this Makefile removes the '/'. It is supposed to only remove the last 'bin/' to 'bin'.
So, in my case the CROSS_COMPILE  is: 
/home/myname/bin/kendryte/kendryte-toolchain/bin/ 
After subst it is:
/home/myname/binkendryte/kendryte-toolchain/bin
Which, of course, does not exist.