### PR TITLE
Remove static data used by uart_rx_irq()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,9 +16,14 @@
 ######################
 *.log
 
-# VIM Swap Files
+# VIM Swap / Temp Files
 ######################
 *.swp
+*~
+
+# ctags data
+######################
+tags
 
 # Build directory
 ######################


### PR DESCRIPTION
The static variables could prevent the irq from being re-entrant,
causing corruption of the variables if one uart interrupts another.

Also removed some compiler warnings.