### PR TITLE
Esp32 network

### DIFF
--- a/components/micropython/port/src/standard_lib/include/esp32_spi.h
+++ b/components/micropython/port/src/standard_lib/include/esp32_spi.h
@@ -4,7 +4,7 @@
 #include <stdint.h>
 
 /* clang-format off */
-#define ESP32_SPI_DEBUG                 (0)
+#define ESP32_SPI_DEBUG                 (1)
 
 #define ESP32_ADC_CH_NUM                (5)
 

--- a/components/micropython/port/src/standard_lib/include/esp32_spi.h
+++ b/components/micropython/port/src/standard_lib/include/esp32_spi.h
@@ -4,7 +4,7 @@
 #include <stdint.h>
 
 /* clang-format off */
-#define ESP32_SPI_DEBUG                 (1)
+#define ESP32_SPI_DEBUG                 (0)
 
 #define ESP32_ADC_CH_NUM                (5)
 

--- a/components/micropython/port/src/standard_lib/network/esp32/esp32_spi.c
+++ b/components/micropython/port/src/standard_lib/network/esp32/esp32_spi.c
@@ -7,6 +7,8 @@
 #include "sysctl.h"
 #include "fpioa.h"
 
+#define ESP32_SPI_DEBUG 1
+
 // Cached values of retrieved data
 char ssid[32] = {0};
 uint8_t mac[32] = {0};
@@ -660,6 +662,7 @@ esp32_spi_aps_list_t *esp32_spi_get_scan_networks(void)
 
         aps->aps[i]->rssi = (int8_t)(rssi->params[0]->param[0]);
 #if ESP32_SPI_DEBUG
+	printf("\tSSID:%s", aps->aps[i]->ssid);
         printf("\t\t\trssi:%02x\r\n", rssi->params[0]->param[0]);
 #endif
         rssi->del(rssi);
@@ -717,7 +720,7 @@ esp32_spi_aps_list_t *esp32_spi_scan_networks(void)
  */
 int8_t esp32_spi_wifi_set_network(uint8_t *ssid)
 {
-    esp32_spi_params_t *send = esp32_spi_params_alloc_1param(strlen((const char*)ssid), ssid);
+    esp32_spi_params_t *send = esp32_spi_params_alloc_1param(strlen(ssid), ssid);
     esp32_spi_params_t *resp = esp32_spi_send_command_get_response(SET_NET_CMD, send, NULL, 0, 0);
     send->del(send);
 
@@ -750,7 +753,7 @@ Sets the desired access point ssid and passphrase
 */
 int8_t esp32_spi_wifi_wifi_set_passphrase(uint8_t *ssid, uint8_t *passphrase)
 {
-    esp32_spi_params_t *send = esp32_spi_params_alloc_2param(strlen((const char*)ssid), ssid, strlen((const char*)passphrase), passphrase);
+    esp32_spi_params_t *send = esp32_spi_params_alloc_2param(strlen(ssid), ssid, strlen(passphrase), passphrase);
     esp32_spi_params_t *resp = esp32_spi_send_command_get_response(SET_PASSPHRASE_CMD, send, NULL, 0, 0);
     send->del(send);
 
@@ -985,7 +988,7 @@ int8_t esp32_spi_connect_AP(uint8_t *ssid, uint8_t *password, uint8_t retry_time
 //Converts a bytearray IP address to a dotted-quad string for printing
 void esp32_spi_pretty_ip(uint8_t *ip, uint8_t *str_ip)
 {
-    sprintf((char*)str_ip, "%d.%d.%d.%d", ip[0], ip[1], ip[2], ip[3]);
+    sprintf(str_ip, "%d.%d.%d.%d", ip[0], ip[1], ip[2], ip[3]);
     return;
 }
 
@@ -1004,7 +1007,7 @@ int8_t esp32_spi_get_host_by_name(uint8_t *hostname, uint8_t *ip)
     printf("*** Get host by name\r\n");
 #endif
 
-    esp32_spi_params_t *send = esp32_spi_params_alloc_1param(strlen((const char*)hostname), hostname);
+    esp32_spi_params_t *send = esp32_spi_params_alloc_1param(strlen(hostname), hostname);
     esp32_spi_params_t *resp = esp32_spi_send_command_get_response(REQ_HOST_BY_NAME_CMD, send, NULL, 0, 0);
     send->del(send);
 
@@ -1181,7 +1184,7 @@ int8_t esp32_spi_socket_open(uint8_t sock_num, uint8_t *dest, uint8_t dest_type,
         send->params_num = 5;
         send->params = (void *)malloc(sizeof(void *) * send->params_num);
         //
-        param_len = strlen((const char*)dest);
+        param_len = strlen(dest);
         send->params[0] = (esp32_spi_param_t *)malloc(sizeof(esp32_spi_param_t));
         send->params[0]->param_len = param_len;
         send->params[0]->param = (uint8_t *)malloc(sizeof(uint8_t) * param_len);
@@ -1647,7 +1650,7 @@ uint8_t connect_server_port(char *host, uint16_t port)
     if (sock != 0xff)
     {
         uint8_t ip[6];
-        if (esp32_spi_get_host_by_name((uint8_t*)host, ip) == 0)
+        if (esp32_spi_get_host_by_name(host, ip) == 0)
         {
             if (esp32_spi_socket_connect(sock, ip, 0, port, TCP_MODE) != 0)
             {

--- a/components/micropython/port/src/standard_lib/network/esp32/mod_esp32.c
+++ b/components/micropython/port/src/standard_lib/network/esp32/mod_esp32.c
@@ -32,12 +32,13 @@ STATIC mp_obj_t esp32_nic_ifconfig(mp_obj_t self_in) {
 		return mp_const_none;
 	}
 
-	mp_obj_t tuple[3] = { mp_obj_new_str( inet->localIp, 4),
-						  mp_obj_new_str(inet->subnetMask, 4),
-						  mp_obj_new_str(inet->gatewayIp, 4)
+	mp_obj_t tuple[3] = {   
+        tuple[0] = netutils_format_ipv4_addr( inet->localIp, NETUTILS_BIG ),
+        tuple[1] = netutils_format_ipv4_addr( inet->subnetMask, NETUTILS_BIG ),
+        tuple[2] = netutils_format_ipv4_addr( inet->gatewayIp, NETUTILS_BIG )
 						};
 
-	return mp_obj_new_tuple(MP_ARRAY_SIZE(tuple), tuple);
+	return mp_obj_new_tuple(3, tuple);
 }
 
 STATIC mp_obj_t esp32_nic_isconnected(mp_obj_t self_in) {

--- a/components/micropython/port/src/standard_lib/network/esp32/mod_esp32.c
+++ b/components/micropython/port/src/standard_lib/network/esp32/mod_esp32.c
@@ -1,5 +1,6 @@
 #include <string.h>
 #include <stdlib.h>
+#include <stdio.h>
 #include "py/objtuple.h"
 #include "py/objlist.h"
 #include "py/stream.h"
@@ -10,6 +11,7 @@
 #include "modnetwork.h"
 #include "modmachine.h"
 #include "mpconfigboard.h"
+#include "sleep.h"
 
 #include "esp32_spi.h"
 #include "esp32_spi_io.h"
@@ -20,8 +22,136 @@ typedef struct _esp32_nic_obj_t
     mp_obj_base_t base;
 
 } esp32_nic_obj_t;
+STATIC bool nic_connected = false;
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+STATIC mp_obj_t esp32_nic_ifconfig(mp_obj_t self_in) {
+    esp32_spi_net_t* inet = esp32_spi_get_network_data();
+	if(inet == NULL)
+	{
+		return mp_const_none;
+	}
+
+	mp_obj_t tuple[3] = { mp_obj_new_str( inet->localIp, 4),
+						  mp_obj_new_str(inet->subnetMask, 4),
+						  mp_obj_new_str(inet->gatewayIp, 4)
+						};
+
+	return mp_obj_new_tuple(MP_ARRAY_SIZE(tuple), tuple);
+}
+
+STATIC mp_obj_t esp32_nic_isconnected(mp_obj_t self_in) {
+    return mp_obj_new_bool(nic_connected);
+}
+
+STATIC mp_obj_t esp32_nic_disconnect(mp_obj_t self_in) {
+    printf("%s not Supported!\r\n", __func__);
+    return mp_const_none;
+}
+
+STATIC mp_obj_t esp32_nic_ping(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+	enum { ARG_host, ARG_host_type};
+	esp32_nic_obj_t* self = NULL;
+    static const mp_arg_t allowed_args[] = {
+        { MP_QSTR_host, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_obj = MP_OBJ_NULL} },
+        { MP_QSTR_host_type, MP_ARG_INT, {.u_obj = mp_const_none} },
+        // { MP_QSTR_host_type, MP_ARG_INT, {.u_obj = mp_const_none} },
+    };
+
+    // parse args
+    mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
+    mp_arg_parse_all(n_args - 1, pos_args + 1, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+
+	//get nic
+	if((mp_obj_type_t*)&mod_network_nic_type_esp32 == mp_obj_get_type(pos_args[0]))
+	{
+		mp_printf(&mp_plat_print, "[MaixPy] %s | get nic\n",__func__);
+		self = pos_args[0];
+	}
+    // get host
+    size_t host_len =0;
+    const uint8_t *host = NULL;
+	if (args[ARG_host].u_obj != MP_OBJ_NULL) {
+        if(mp_obj_get_type(args[ARG_host].u_obj) == &mp_type_str)
+            host = mp_obj_str_get_data(args[ARG_host].u_obj, &host_len);
+        else if(mp_obj_get_type(args[ARG_host].u_obj) == &mp_type_set){
+            host = MP_OBJ_TO_PTR(args[ARG_host].u_obj);
+        }
+    }
+        
+    
+    // get host type (host name or address)
+    int host_type = 1;
+	if (args[ARG_host_type].u_int != mp_const_none) {
+        host_type = args[ARG_host_type].u_int;
+    }
+    uint16_t time = esp32_spi_ping((uint8_t*)host, host_type, 100);
+
+    return mp_obj_new_int(time);
+}
+
+STATIC mp_obj_t esp32_nic_connect( size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args )
+{
+	enum { ARG_ssid, ARG_key};
+	esp32_nic_obj_t* self = NULL;
+    static const mp_arg_t allowed_args[] = {
+        { MP_QSTR_ssid, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_obj = MP_OBJ_NULL} },
+        { MP_QSTR_key, MP_ARG_OBJ, {.u_obj = mp_const_none} },
+    };
+
+    // parse args
+    mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
+    mp_arg_parse_all(n_args - 1, pos_args + 1, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+
+	//get nic
+	if((mp_obj_type_t*)&mod_network_nic_type_esp32 == mp_obj_get_type(pos_args[0]))
+	{
+		mp_printf(&mp_plat_print, "[MaixPy] %s | get nic\n",__func__);
+		self = pos_args[0];
+	}
+    // get ssid
+    size_t ssid_len =0;
+    const char *ssid = NULL;
+	if (args[ARG_ssid].u_obj != mp_const_none) {
+        ssid = mp_obj_str_get_data(args[ARG_ssid].u_obj, &ssid_len);
+    }		
+    // get key
+    size_t key_len = 0;
+    const char *key = NULL;
+    if (args[ARG_key].u_obj != mp_const_none) {
+        key = mp_obj_str_get_data(args[1].u_obj, &key_len);
+    }
+    // connect to AP
+    
+    int8_t err = esp32_spi_connect_AP((uint8_t*)ssid, (uint8_t*)key, 10);
+    if(err == 0)
+    	nic_connected = 1;
+
+    return mp_const_none;
+}
+
+STATIC mp_obj_t esp32_scan_wifi( mp_obj_t self_in )
+{
+    mp_obj_t list = mp_obj_new_list(0, NULL);
+    char fail_str[30] ;
+    bool end;
+    int err_code = 0;
+
+    esp32_spi_aps_list_t* aps_list = esp32_spi_scan_networks();
+    uint32_t count = aps_list->aps_num;
+    if(aps_list == NULL)
+        goto err;
+    for(int i=0; i<count; i++)
+    {
+        esp32_spi_ap_t* ap = aps_list->aps[i];
+        mp_obj_list_append(list, mp_obj_new_str((char*)ap->ssid, strlen(ap->ssid)));
+    }
+    aps_list->del(aps_list);
+    return list;
+err:
+    snprintf(fail_str, sizeof(fail_str), "wifi scan fail:%d", err_code);
+    mp_raise_msg(&mp_type_OSError, fail_str);
+}
 
 STATIC void esp32_make_new_helper(esp32_nic_obj_t *self, size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args)
 {
@@ -149,13 +279,147 @@ STATIC mp_obj_t esp32_adc(mp_obj_t self_in)
 
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(esp32_adc_obj, esp32_adc);
 
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(esp32_scan_wifi_obj, esp32_scan_wifi);
+STATIC MP_DEFINE_CONST_FUN_OBJ_KW(esp32_nic_connect_obj, 1, esp32_nic_connect);
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(esp32_nic_disconnect_obj, esp32_nic_disconnect);
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(esp32_nic_isconnected_obj, esp32_nic_isconnected);
+STATIC MP_DEFINE_CONST_FUN_OBJ_KW(esp32_nic_ping_obj, 1, esp32_nic_ping);
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(esp32_nic_ifconfig_obj, esp32_nic_ifconfig);
+
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 STATIC const mp_rom_map_elem_t esp32_locals_dict_table[] = {
     {MP_ROM_QSTR(MP_QSTR_adc), MP_ROM_PTR(&esp32_adc_obj)},
+    {MP_ROM_QSTR(MP_QSTR_scan), MP_ROM_PTR(&esp32_scan_wifi_obj)},
+    { MP_ROM_QSTR(MP_QSTR_connect), MP_ROM_PTR(&esp32_nic_connect_obj) },
+    { MP_ROM_QSTR(MP_QSTR_disconnect), MP_ROM_PTR(&esp32_nic_disconnect_obj) },  
+    { MP_ROM_QSTR(MP_QSTR_isconnected), MP_ROM_PTR(&esp32_nic_isconnected_obj) },
+    { MP_ROM_QSTR(MP_QSTR_ifconfig), MP_ROM_PTR(&esp32_nic_ifconfig_obj) },
+    { MP_ROM_QSTR(MP_QSTR_ping), MP_ROM_PTR(&esp32_nic_ping_obj) },
+    { MP_ROM_QSTR(MP_QSTR_OPEN), MP_ROM_INT(0) },
+    { MP_ROM_QSTR(MP_QSTR_WPA_PSK), MP_ROM_INT(2) },
+    { MP_ROM_QSTR(MP_QSTR_WPA2_PSK), MP_ROM_INT(3) },
+    { MP_ROM_QSTR(MP_QSTR_WPA_WPA2_PSK), MP_ROM_INT(4) },
 };
 
 STATIC MP_DEFINE_CONST_DICT(esp32_locals_dict, esp32_locals_dict_table);
+
+STATIC uint8_t sock = 0;
+
+STATIC int esp32_socket_socket(mod_network_socket_obj_t *socket, int *_errno) {
+    return 0;
+}
+
+STATIC int esp32_socket_connect(mod_network_socket_obj_t *socket, byte *ip, mp_uint_t port, int *_errno) {
+	if((mp_obj_type_t*)&mod_network_nic_type_esp32 != mp_obj_get_type(MP_OBJ_TO_PTR(socket->nic)))
+	{
+		mp_printf(&mp_plat_print, "[MaixPy] %s | esp32_socket_connect can not get nic\n",__func__);
+		*_errno = -1;
+		return -1;
+	}
+
+	switch(socket->u_param.type)
+	{
+		case MOD_NETWORK_SOCK_STREAM:
+		{
+            sock = esp32_spi_get_socket();
+            int8_t conn = esp32_spi_socket_connect(sock, ip, 0, port, TCP_MODE);
+			if(-1 == conn)
+			{
+				*_errno = -1;
+				return -1;
+			}
+			break;
+		}
+		case MOD_NETWORK_SOCK_DGRAM:
+		{
+            mp_printf(&mp_plat_print, "[MaixPy] %s | esp32_socket_connect UDP NOT implemented yet\n",__func__);
+            *_errno = -1;
+            return -1;
+			// break;
+		}
+		default:
+		{
+            sock = esp32_spi_get_socket();
+            int8_t conn = esp32_spi_socket_connect(sock, ip, 0, port, TCP_MODE);
+			if(-1 == conn)
+			{
+				*_errno = -1;
+				return -1;
+			}
+			break;
+		}
+	}
+    return 0;
+}
+
+STATIC mp_uint_t esp32_socket_recv(mod_network_socket_obj_t *socket, byte *buf, mp_uint_t len, int *_errno) {
+	if((mp_obj_type_t*)&mod_network_nic_type_esp32 != mp_obj_get_type(MP_OBJ_TO_PTR(socket->nic)))
+	{
+		mp_printf(&mp_plat_print, "[MaixPy] %s | esp32_socket_connect can not get nic\n",__func__);
+		*_errno = MP_EPIPE;
+		return -1;
+	}
+
+	uint16_t read_len = 0;
+    uint16_t len1 = esp32_spi_socket_available(sock);
+    if(len1 == 0)
+    {
+		*_errno = MP_EIO;
+        return read_len;
+    }
+
+	read_len = esp32_spi_socket_read(sock, (uint8_t*)buf, len1>len?len:len1);
+	if(0 == read_len)
+		*_errno = MP_EIO;
+	return read_len;
+}
+
+STATIC mp_uint_t esp32_socket_send(mod_network_socket_obj_t *socket, const byte *buf, mp_uint_t len, int *_errno) {
+
+	if((mp_obj_type_t*)&mod_network_nic_type_esp32 != mp_obj_get_type(MP_OBJ_TO_PTR(socket->nic)))
+	{
+		mp_printf(&mp_plat_print, "[MaixPy] %s | esp32_socket_connect can not get nic\n",__func__);
+		*_errno = MP_EPIPE;
+		return -1;
+	}
+    int status = esp32_spi_socket_status(sock);
+    if(status == SOCKET_ESTABLISHED)
+
+	if(esp32_spi_socket_write(sock, (uint8_t*)buf, len ) == 0)
+	{
+		mp_printf(&mp_plat_print, "[MaixPy] %s | send data failed\n",__func__);
+
+		*_errno = MP_EIO;
+		return -1;
+	}
+	
+    return len;
+}
+
+STATIC void esp32_socket_close(mod_network_socket_obj_t *socket) {
+	if((mp_obj_type_t*)&mod_network_nic_type_esp32 != mp_obj_get_type(MP_OBJ_TO_PTR(socket->nic)))
+	{
+		mp_printf(&mp_plat_print, "[MaixPy] %s | esp32_socket_connect can not get nic\n",__func__);
+		return ;
+	}
+
+    int8_t status = esp32_spi_socket_close(sock);
+}
+
+STATIC int esp32_socket_gethostbyname(mp_obj_t nic, const char *name, mp_uint_t len, uint8_t* out_ip) {
+	if((mp_obj_type_t*)&mod_network_nic_type_esp32 != mp_obj_get_type(nic))
+	{
+        return -1;
+    }
+
+    uint8_t tmp_ip[6];
+    if(esp32_spi_get_host_by_name((uint8_t*)name, tmp_ip) == -1)
+        return -1;
+
+    memcpy(out_ip, tmp_ip, 4);
+    return true;
+}
 
 const mod_network_nic_type_t mod_network_nic_type_esp32 = {
     .base = {
@@ -164,13 +428,13 @@ const mod_network_nic_type_t mod_network_nic_type_esp32 = {
         .make_new = esp32_make_new,
         .locals_dict = (mp_obj_dict_t *)&esp32_locals_dict,
     },
+    .gethostbyname = esp32_socket_gethostbyname,
+    .connect = esp32_socket_connect,
+    .socket = esp32_socket_socket,
+    .send = esp32_socket_send,
+    .recv = esp32_socket_recv,
+    .close = esp32_socket_close,
     /*
-    .gethostbyname = esp8285_socket_gethostbyname,
-    .connect = esp8285_socket_connect,
-    .socket = esp8285_socket_socket,
-    .send = esp8285_socket_send,
-    .recv = esp8285_socket_recv,
-    .close = esp8285_socket_close,
     .bind = cc3k_socket_bind,
     .listen = cc3k_socket_listen,
     .accept = cc3k_socket_accept,


### PR DESCRIPTION
Esp32 wifi networking interface implemented. There is few things that needs to be fixed, like esp32 socket number is global static, but should be part of socket (now only 1 socket can be used at the same time).

Here is example i am using for tests:
```
import socket
import network
import utime
from Maix import GPIO
from fpioa_manager import *

#iomap at MaixDuino
fm.register(25,fm.fpioa.GPIOHS10)#cs
fm.register(8,fm.fpioa.GPIOHS11)#rst
fm.register(9,fm.fpioa.GPIOHS12)#rdy
fm.register(28,fm.fpioa.GPIOHS13)#mosi
fm.register(26,fm.fpioa.GPIOHS14)#miso
fm.register(27,fm.fpioa.GPIOHS15)#sclk

nic = network.ESP32_SPI(cs=fm.fpioa.GPIOHS10,rst=fm.fpioa.GPIOHS11,rdy=fm.fpioa.GPIOHS12,
mosi=fm.fpioa.GPIOHS13,miso=fm.fpioa.GPIOHS14,sclk=fm.fpioa.GPIOHS15)

wifi = nic.scan()
for v in wifi:
    print("%s\n" %(v), end=" ")
print()

nic.isconnected()
nic.connect("sipeed", "12345678")
nic.isconnected()

sock = socket.socket()
addr = socket.getaddrinfo("dl.sipeed.com", 80)[0][-1]
sock.connect(addr)
sock.send('''GET /MAIX/MaixPy/assets/Alice.jpg HTTP/1.1\r\nHost: dl.sipeed.com\r\ncache-control: no-cache\r\n\r\n''')

utime.sleep_ms(300) # some delay is required here (most likely shorter), to let esp32 gatter some data, or esp32 will return data len 0
img = b""
sock.settimeout(10)
while True:
    data = sock.recv(128)
    if len(data) == 0:
        break
    print("rcv:", len(data))
    img = img + data

print(len(img))
sock.close()
nic.ifconfig()
```