### PR TITLE
Fix NameError occurred when boot.py is exited with button A or Ctrl-C

### DIFF
--- a/projects/maixpy_m5stickv/builtin_py/_boot.py
+++ b/projects/maixpy_m5stickv/builtin_py/_boot.py
@@ -44,6 +44,7 @@ import lcd
 import image
 import time
 import uos
+import sys
 
 lcd.init()
 lcd.rotation(2) #Rotate the lcd 180deg


### PR DESCRIPTION
NameError is occurred in calling sys.exit() (boot.py:50 and boot.py:122) due to missing 'import sys'. 