### PR TITLE
fix m5stickv setScreenBrightness

### DIFF
--- a/projects/maixpy_m5stickv/builtin_py/pmu.py
+++ b/projects/maixpy_m5stickv/builtin_py/pmu.py
@@ -33,7 +33,7 @@ class axp192:
         return (self.i2cDev.readfrom(self.axp192Addr, 1))[0]
     
     def setScreenBrightness(self, brightness):
-        self.__writeReg(0x28, (brightness & 0x0f) << 4)
+        self.__writeReg(0x91, (brightness & 0x0f) << 4)
     
     def enableADCs(self, enable):
         if enable == True:


### PR DESCRIPTION
Fixed wrong address.

Initialized with address=0x91
https://github.com/sipeed/MaixPy/blob/master/components/boards/m5stick/src/m5stick.c#L53

And I built fixed bin and flash to device, confirmed "setScreenBrightness(7)" is works well.

ref: https://gist.github.com/takeru/5fe5e6666e922f0917f371aee8aefd5e
