### PR TITLE
MMU test with MaixPy

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,6 @@
 [submodule "tools/kconfig/Kconfiglib"]
 	path = tools/kconfig/Kconfiglib
 	url = https://github.com/ulfalizer/Kconfiglib.git
-[submodule "components/kendryte_sdk/kendryte-standalone-sdk"]
-	path = components/kendryte_sdk/kendryte-standalone-sdk
-	url = https://github.com/sipeed/kendryte-standalone-sdk
 [submodule "tools/flash/kflash_py"]
 	path = tools/flash/kflash_py
 	url = https://github.com/sipeed/kflash.py.git
@@ -20,3 +17,6 @@
 [submodule "tools/spiffs/mkspiffs"]
 	path = tools/spiffs/mkspiffs
 	url = https://github.com/igrr/mkspiffs.git
+[submodule "components/kendryte_sdk/kendryte-standalone-sdk"]
+	path = components/kendryte_sdk/kendryte-standalone-sdk
+	url = https://github.com/elect-gombe/kendryte-standalone-sdk.git

--- a/components/kendryte_sdk/src/sipeed_i2c.c
+++ b/components/kendryte_sdk/src/sipeed_i2c.c
@@ -89,7 +89,7 @@ void maix_i2c_init_as_slave(i2c_device_number_t i2c_num, uint32_t slave_address,
     is_master_mode[i2c_num] = false;
 }
 
-#define time_ms() (unsigned long)(read_csr(mcycle)/(sysctl_clock_get_freq(SYSCTL_CLOCK_CPU)/1000))
+#define time_ms() (unsigned long)(get_cycle()/(sysctl_clock_get_freq(SYSCTL_CLOCK_CPU)/1000))
 
 /**
  * 

--- a/components/micropython/port/include/mphalport.h
+++ b/components/micropython/port/include/mphalport.h
@@ -14,6 +14,8 @@ extern ringbuf_t stdin_ringbuf;
 extern TaskHandle_t mp_main_task_handle;
 #endif
 
+#define mp_hal_stdio_poll(poll_flags) (0)
+
 //uint32_t mp_hal_ticks_us(void);
 //uint32_t mp_hal_ticks_ms(void);
 //uint32_t mp_hal_ticks_cpu(void);

--- a/components/micropython/port/src/maixpy_main.c
+++ b/components/micropython/port/src/maixpy_main.c
@@ -316,14 +316,14 @@ void load_config_from_spiffs(config_data_t* config)
 	SPIFFS_close(&spiffs_user_mount_handle.fs, fd);
 }
 
-#if MICROPY_ENABLE_COMPILER
+#if MICROPY_ENABLE_COMPILER 
 void pyexec_str(vstr_t* str) {
     nlr_buf_t nlr;
     if (nlr_push(&nlr) == 0) {
         mp_lexer_t *lex = mp_lexer_new_from_str_len(MP_QSTR__lt_stdin_gt_, str->buf, str->len, 0);
         qstr source_name = lex->source_name;
         mp_parse_tree_t parse_tree = mp_parse(lex, MP_PARSE_FILE_INPUT);
-        mp_obj_t module_fun = mp_compile(&parse_tree, source_name, MP_EMIT_OPT_NONE, true);
+        mp_obj_t module_fun = mp_compile(&parse_tree, source_name, true);
         mp_call_function_0(module_fun);
         nlr_pop();
     } else {
@@ -526,18 +526,17 @@ int maixpy_main()
 	sysctl_clock_enable(SYSCTL_CLOCK_AI);
 	sysctl_set_power_mode(SYSCTL_POWER_BANK6, SYSCTL_POWER_V18);
 	sysctl_set_power_mode(SYSCTL_POWER_BANK7, SYSCTL_POWER_V18);
-    sysctl_enable_irq();
+	sysctl_enable_irq();
 	rtc_init();
 	rtc_timer_set(2019,1, 1,0, 0, 0);
-	flash_init(&manuf_id, &device_id);
 	printk("[MAIXPY]Flash:0x%02x:0x%02x\r\n", manuf_id, device_id);
-    /* Init SPI IO map and function settings */
-    sysctl_set_spi0_dvp_data(1);
+	/* Init SPI IO map and function settings */
+	sysctl_set_spi0_dvp_data(1);
 	/* open core 1 */
 	printk("open second core...\r\n");
-    register_core1(core1_function, 0);
+	register_core1(core1_function, 0);
     
-#if MICROPY_PY_THREAD 
+#if MICROPY_PY_THREAD
 	xTaskCreateAtProcessor(0, // processor
 						 mp_task, // function entry
 						 "mp_task", //task name
@@ -552,13 +551,14 @@ int maixpy_main()
 #endif
 	return 0;
 }
+
 void do_str(const char *src, mp_parse_input_kind_t input_kind) {
     nlr_buf_t nlr;
     if (nlr_push(&nlr) == 0) {
         mp_lexer_t *lex = mp_lexer_new_from_str_len(MP_QSTR__lt_stdin_gt_, src, strlen(src), 0);
         qstr source_name = lex->source_name;
         mp_parse_tree_t parse_tree = mp_parse(lex, input_kind);
-        mp_obj_t module_fun = mp_compile(&parse_tree, source_name, MP_EMIT_OPT_NONE, true);
+        mp_obj_t module_fun = mp_compile(&parse_tree, source_name, true);
         mp_call_function_0(module_fun);
         nlr_pop();
     } else {

--- a/components/micropython/port/src/maixpy_main.c
+++ b/components/micropython/port/src/maixpy_main.c
@@ -323,7 +323,7 @@ void pyexec_str(vstr_t* str) {
         mp_lexer_t *lex = mp_lexer_new_from_str_len(MP_QSTR__lt_stdin_gt_, str->buf, str->len, 0);
         qstr source_name = lex->source_name;
         mp_parse_tree_t parse_tree = mp_parse(lex, MP_PARSE_FILE_INPUT);
-        mp_obj_t module_fun = mp_compile(&parse_tree, source_name, true);
+        mp_obj_t module_fun = mp_compile(&parse_tree, source_name, MP_EMIT_OPT_NONE, true);
         mp_call_function_0(module_fun);
         nlr_pop();
     } else {
@@ -558,7 +558,7 @@ void do_str(const char *src, mp_parse_input_kind_t input_kind) {
         mp_lexer_t *lex = mp_lexer_new_from_str_len(MP_QSTR__lt_stdin_gt_, src, strlen(src), 0);
         qstr source_name = lex->source_name;
         mp_parse_tree_t parse_tree = mp_parse(lex, input_kind);
-        mp_obj_t module_fun = mp_compile(&parse_tree, source_name, true);
+        mp_obj_t module_fun = mp_compile(&parse_tree, source_name, MP_EMIT_OPT_NONE, true);
         mp_call_function_0(module_fun);
         nlr_pop();
     } else {

--- a/components/micropython/port/src/modules/ultrasonic/src/ultrasonic.c
+++ b/components/micropython/port/src/modules/ultrasonic/src/ultrasonic.c
@@ -6,7 +6,7 @@
 #include "sysctl.h"
 #include "printf.h"
 
-#define time_us()  (unsigned long)(read_csr(mcycle)/(sysctl_clock_get_freq(SYSCTL_CLOCK_CPU)/1000000))
+#define time_us()  (unsigned long)(get_cycle()/(sysctl_clock_get_freq(SYSCTL_CLOCK_CPU)/1000000))
 
 typedef void (*set_pin_func_t)(uint8_t gpio, gpio_pin_value_t value);
 typedef gpio_pin_value_t (*get_pin_func_t)(uint8_t gpio);

--- a/components/micropython/port/src/mphalport.c
+++ b/components/micropython/port/src/mphalport.c
@@ -67,17 +67,17 @@ void mp_hal_debug_tx_strn_cooked(void *env, const char *str, size_t len) {
 
 mp_uint_t inline mp_hal_ticks_cpu(void)
 {
-	return (unsigned long)(read_csr(mcycle));
+	return (unsigned long)(get_cycle());
 }
 
 mp_uint_t inline mp_hal_ticks_us(void)
 {
-	return (unsigned long)(read_csr(mcycle)/(sysctl_clock_get_freq(SYSCTL_CLOCK_CPU)/1000000));
+	return (unsigned long)(get_cycle()/(sysctl_clock_get_freq(SYSCTL_CLOCK_CPU)/1000000));
 }
 
 mp_uint_t inline mp_hal_ticks_ms(void)
 {
-    return (unsigned long)(read_csr(mcycle)/(sysctl_clock_get_freq(SYSCTL_CLOCK_CPU)/1000));
+    return (unsigned long)(get_cycle()/(sysctl_clock_get_freq(SYSCTL_CLOCK_CPU)/1000));
 }
 
 void mp_hal_delay_ms(mp_uint_t ms) 

--- a/components/micropython/port/src/video/video_hal.c
+++ b/components/micropython/port/src/video/video_hal.c
@@ -62,7 +62,7 @@ int video_hal_display(image_t* img, video_display_roi_t img_roi)
 
 uint64_t inline video_hal_ticks_us(void)
 {
-    return (uint64_t)(read_csr(mcycle)/(sysctl_clock_get_freq(SYSCTL_CLOCK_CPU)/1000000));
+    return (uint64_t)(get_cycle()/(sysctl_clock_get_freq(SYSCTL_CLOCK_CPU)/1000000));
 }
 
 

--- a/projects/mmu_code/compile/compile_flags.cmake
+++ b/projects/mmu_code/compile/compile_flags.cmake
@@ -38,6 +38,8 @@ set(CMAKE_C_FLAGS 	-mcmodel=medany
                     -Wno-error=restrict
                     -Wno-error=sequence-point
                     -Wno-int-to-pointer-cast
+		    -Wl,--no-relax
+		    -g3
                     )
 ################################
 
@@ -75,6 +77,8 @@ set(CMAKE_CXX_FLAGS -mcmodel=medany
                     -Wno-error=restrict
                     -Wno-error=sequence-point
                     -Wno-int-to-pointer-cast
+		    -Wl,--no-relax
+		    -g3
                     )
 ################################
 
@@ -83,6 +87,7 @@ set(LINK_FLAGS ${LINK_FLAGS}
             -Wl,-static
             -nostartfiles
             -Wl,--gc-sections
+	    -Wl,--no-relax
             -Wl,-EL
             -T ${PROJECT_SOURCE_DIR}/compile/kendryte.ld
             -Wl,--start-group

--- a/projects/mmu_code/compile/priority.conf
+++ b/projects/mmu_code/compile/priority.conf
@@ -5,6 +5,7 @@ kendryte_sdk
 drivers
 spiffs
 boards
+micropython
 main
 
 

--- a/projects/mmu_code/main/CMakeLists.txt
+++ b/projects/mmu_code/main/CMakeLists.txt
@@ -12,7 +12,7 @@ list(APPEND ADD_SRCS  "src/main.c"
 ###############################################
 
 ###### Add required/dependent components ######
-list(APPEND ADD_REQUIREMENTS kendryte_sdk drivers boards)
+list(APPEND ADD_REQUIREMENTS kendryte_sdk drivers boards micropython)
 ###############################################
 
 ############ Add static libs ##################

--- a/projects/mmu_code/project.py
+++ b/projects/mmu_code/project.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #-*- coding = utf-8 -*-
 
 import sys, os


### PR DESCRIPTION
Support usermode csr access.

![image](https://user-images.githubusercontent.com/13552050/65772963-4c0fb880-e176-11e9-985e-f891d8ce8825.png)

- Fix missing submodule (kendyte-standalone-sdk).
- Support usermode csr access across usermode and machine mode.

## TODO
- Add multi-core support
- move almost maixpy text area into virtual address for ram saving.
- enable micropython by default (currently by changing in menuconfig)