### PR TITLE
Fixed error message when 'kpu.load()' is failed.

### DIFF
--- a/components/micropython/port/src/Maix/Maix_kpu.c
+++ b/components/micropython/port/src/Maix/Maix_kpu.c
@@ -389,9 +389,7 @@ STATIC mp_obj_t py_kpu_class_load(size_t n_args, const mp_obj_t *pos_args, mp_ma
 
 error:
 {
-    char msg[50];
-    sprintf(msg,"[MAIXPY]kpu: load error:%d", err);
-    mp_raise_ValueError(msg);
+    nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, "[MAIXPY]kpu: load error:%d", err));
 }
 }
 


### PR DESCRIPTION
Could not read error message.
"msg" that passed to mp_raise_ValueError should not be local buffer.
 
https://github.com/sipeed/MaixPy/issues/175

Now we can see error code:
<img width="492" alt="スクリーンショット 2019-10-19 22 48 35" src="https://user-images.githubusercontent.com/82017/67146121-ab1ea400-f2c2-11e9-9815-b3bd598da178.png">
