### PR TITLE
Fix bug triggered in out-of-memory situation

### DIFF
--- a/components/kendryte_sdk/src/sipeed_yolo2.c
+++ b/components/kendryte_sdk/src/sipeed_yolo2.c
@@ -58,6 +58,10 @@ int region_layer_init(region_layer_t *rl, void* ctx)
     //rl->scale = output_scale;
     //rl->bias = output_bias;
 
+    // Initialize for out-of-memory situations
+    rl->probs_buf = NULL;
+    rl->probs = NULL;
+
     /*rl->output = malloc(rl->output_number * sizeof(float));
     if (rl->output == NULL)
     {


### PR DESCRIPTION
In region_layer_init() three mallocs() are executed. If one of the
first two malloc() calls returns NULL, uninitialized pointers
were passed to free after the jump to label "malloc_error".

See the three malloc() calls here:

https://github.com/sipeed/MaixPy/blob/284ce83d6b6f6fe61e932cee439f4d0ec192028d/components/kendryte_sdk/src/sipeed_yolo2.c#L67

and the corresponding free() calls here:

https://github.com/sipeed/MaixPy/blob/284ce83d6b6f6fe61e932cee439f4d0ec192028d/components/kendryte_sdk/src/sipeed_yolo2.c#L107