### PR TITLE
Fix bug that cannot play wav, and _boot.py for m5stickv change to run without pye

### DIFF
--- a/components/micropython/port/src/audio/wav/include/wav.h
+++ b/components/micropython/port/src/audio/wav/include/wav.h
@@ -29,7 +29,7 @@ Finally, the data chunk contains the sample data:
 
 #include "stdint.h"
 
-#define WAV_PLAY_DMA_CHANNEL DMAC_CHANNEL4
+#define WAV_PLAY_DMA_CHANNEL DMAC_CHANNEL3
 #define WAV_RECORD_DMA_CHANNEL DMAC_CHANNEL3
 
 //---------------------------------decode-----------------------------

--- a/projects/maixpy_m5stickv/builtin_py/_boot.py
+++ b/projects/maixpy_m5stickv/builtin_py/_boot.py
@@ -38,7 +38,10 @@ import gc, uos, sys
 import machine
 from board import board_info
 from fpioa_manager import fm
-from pye_mp import pye
+try:
+    from pye_mp import pye
+except:
+    pass
 from Maix import FPIOA, GPIO
 
 banner = '''


### PR DESCRIPTION
Fix Bug for 02b1f12

and 

Fixed the problem that M5StickV can't boot without pye in _boot.py