### PR TITLE
Add support for widora airv r3 board.

### DIFF
--- a/components/boards/config/airv3_big.json
+++ b/components/boards/config/airv3_big.json
@@ -1,0 +1,38 @@
+{
+    "config_name": "airv3_big",
+    "lcd": {
+        "rst" : 0,
+        "dcx" : 38,
+        "ss" : 36, 
+        "clk" : 39,
+        "height": 240,
+        "width": 320,
+        "invert": 0,
+        "offset_w0": 0,
+        "offset_h0": 0,
+        "offset_w1": 0,
+        "offset_h1": 0,
+        "dir": 96,
+        "oct": 1
+    }, 
+    "sensor": {
+        "cmos_pclk":47,
+        "cmos_xclk":46,
+        "cmos_href":45,
+        "cmos_pwdn":13,
+        "cmos_vsync":43,
+        "cmos_rst":42,
+        "reg_width":16,
+        "i2c_num":2,
+        "pin_clk":41,
+        "pin_sda":40
+    },
+    "sdcard":{
+        "sclk":27,
+        "mosi":28,
+        "miso":26,
+        "cs":29
+    }
+}
+
+

--- a/components/boards/config/airv3_small.json
+++ b/components/boards/config/airv3_small.json
@@ -1,0 +1,36 @@
+{
+    "config_name": "airv3_small",
+    "lcd": {
+        "rst" : 11,
+        "dcx" : 38,
+        "ss" : 37,
+        "clk" : 39,
+        "height": 135,
+        "width": 240,
+        "invert": 1,
+        "offset_w0": 40,
+        "offset_h0": 53,
+        "offset_w1": 40,
+        "offset_h1": 53,
+        "dir": 96,
+        "oct": 0
+    }, 
+    "sensor": {
+        "cmos_pclk":47,
+        "cmos_xclk":46,
+        "cmos_href":45,
+        "cmos_pwdn":13,
+        "cmos_vsync":43,
+        "cmos_rst":42,
+        "reg_width":16,
+        "i2c_num":2,
+        "pin_clk":41,
+        "pin_sda":40
+    },
+    "sdcard":{
+        "sclk":27,
+        "mosi":28,
+        "miso":26,
+        "cs":29
+    }
+}

--- a/components/micropython/port/src/omv/py/py_lcd.c
+++ b/components/micropython/port/src/omv/py/py_lcd.c
@@ -138,6 +138,7 @@ void py_lcd_load_config(lcd_para_t *lcd_cfg)
         PY_LCD_CHECK_CONFIG(offset_h1, &lcd_cfg->offset_h1);
         PY_LCD_CHECK_CONFIG(dir, &lcd_cfg->dir);
         PY_LCD_CHECK_CONFIG(lcd_type, &lcd_cfg->lcd_type);
+        PY_LCD_CHECK_CONFIG(oct, &lcd_cfg->oct);
 
         // mp_printf(&mp_plat_print, "[%s]: rst=%d, dcx=%d, ss=%d, clk=%d\r\n",
         //           __func__, lcd_cfg->rst_pin, lcd_cfg->dcx_pin, lcd_cfg->cs_pin, lcd_cfg->clk_pin);


### PR DESCRIPTION
A neat and powerful K210 development board!
https://mangopi.org/airv3
![image](https://user-images.githubusercontent.com/20812356/115712709-ab13ce80-a3a7-11eb-8fd9-0ba671089024.png)

Small and big tfts are supported. For the onboard small tft, use the _small.json, else use the _big.json.
In maixpy ide, choosing kd233 seems to work fine.
Board pinmap:
```json
    "board_info": {
        "pin_num": 48,
        "JTAG_TCK": 0,
        "JTAG_TDI": 1,
        "JTAG_TMS": 2,
        "JTAG_TDO": 3,
        "ISP_RX": 4,
        "ISP_TX": 5,
        "WIFI_TX": 6,
        "WIFI_RX": 7,
        "WIFI_EN": 8,
        "PIN9": 9,
        "PIN10": 10,
        "PIN11": 11,
        "PIN12": 12,
        "DVP_PWDN": 13,
        "LED_IR": 14,
        "LED_RGB": 15,
        "BOOT_KEY": 16,
        "LED_1": 17,
        "LED_2": 18,
        "USR_A": 19,
        "USR_B": 20,
        "PIN21": 21,
        "PIN22": 22,
        "PIN23": 23,
        "PIN24": 24,
        "PIN25": 25,
        "SPI0_MISO": 26,
        "SPI0_CLK": 27,
        "SPI0_MOSI": 28,
        "SPI0_CS0": 29,
        "I2S_LRCK": 30,
        "I2S_SCLK": 31,
        "I2S_DIN": 32,
        "I2S_LRCK_2": 33,
        "I2S_DOUT": 34,
        "I2S_SCLK_2": 35,
        "LCD_CS": 36,
        "LCD_CS_2": 37,
        "LCD_DC": 38,
        "LCD_WR": 39,
        "DVP_SDA": 40,
        "DVP_SCL": 41,
        "DVP_RST": 42,
        "DVP_VSYNC": 43,
        "DVP_SDA_2": 44,
        "DVP_HSYNC": 45,
        "DVP_XCLK": 46,
        "DVP_PCLK": 47,
        "pin_name": [
            "JTAG_TCK",
            "JTAG_TDI",
            "JTAG_TMS",
            "JTAG_TDO",
            "ISP_RX",
            "ISP_TX",
            "WIFI_TX",
            "WIFI_RX",
            "WIFI_EN",
            "PIN9",
            "PIN10",
            "PIN11",
            "PIN12",
            "DVP_PWDN",
            "LED_IR",
            "LED_RGB",
            "BOOT_KEY",
            "LED_1",
            "LED_2",
            "USR_A",
            "USR_B",
            "PIN21",
            "PIN22",
            "PIN23",
            "PIN24",
            "PIN25",
            "SPI0_MISO",
            "SPI0_CLK",
            "SPI0_MOSI",
            "SPI0_CS0",
            "I2S_LRCK",
            "I2S_SCLK",
            "I2S_DIN",
            "I2S_LRCK_2",
            "I2S_DOUT",
            "I2S_SCLK_2",
            "LCD_CS",
            "LCD_CS_2",
            "LCD_DC",
            "LCD_WR",
            "DVP_SDA",
            "DVP_SCL",
            "DVP_RST",
            "DVP_VSYNC",
            "DVP_SDA_2",
            "DVP_HSYNC",
            "DVP_XCLK",
            "DVP_PCLK"
        ]
    }
Note: cs2 is small screen and cs1 is big screen.
lrck/sclk1 is for microphone, 2 is for i2s dac.
```
